### PR TITLE
Fixed up event bugs + enhanced demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage Example is in page/demo/demo_simple_es5.html
     <div id="my_dock_manager" class="my-dock-manager" style="position: relative;"></div>
     <div id="solution_window" data-panel-caption="Solution Explorer" data-panel-icon="test.png" class="solution-window" hidden></div>
     <div id="properties_window" data-panel-caption="Properties" class="properties-window" hidden></div>
-    <div id="problems_window" data-panel-caption="Problems" class="problems-window" hidden></div>
+    <div id="state_window" data-panel-caption="state" class="state-window" hidden></div>
     <div id="editor1_window" data-panel-caption="Steering.h" class="editor1-window editor-host" hidden></div>
     <div id="editor2_window" data-panel-caption="Steering.cpp" class="editor2-window editor-host" hidden></div>
     <div id="infovis" data-panel-caption="Dock Tree Visualizer" class="editor2-window editor-host" hidden></div>
@@ -82,7 +82,7 @@ Usage Example is in page/demo/demo_simple_es5.html
     let properties = new PanelContainer(document.getElementById("#properties_window"), dockManager);
     let toolbox = new PanelContainer(document.getElementById("#toolbox_window"), dockManager);
     let outline = new PanelContainer(document.getElementById("#outline_window"), dockManager);
-    let problems = new PanelContainer(document.getElementById("#problems_window"), dockManager);
+    let state = new PanelContainer(document.getElementById("#state_window"), dockManager);
     let editor1 = new PanelContainer(document.getElementById("#editor1_window"), dockManager);
     let editor2 = new PanelContainer(document.getElementById("#editor2_window"), dockManager);
     let infovis = new PanelContainer(document.getElementById("infovis"), dockManager);
@@ -93,7 +93,7 @@ Usage Example is in page/demo/demo_simple_es5.html
     let outlineNode = dockManager.dockFill(solutionNode, outline);
     let propertiesNode = dockManager.dockDown(outlineNode, properties, 0.6);
     let outputNode = dockManager.dockDown(documentNode, output, 0.4);
-    let problemsNode = dockManager.dockRight(outputNode, problems, 0.40);
+    let stateNode = dockManager.dockRight(outputNode, state, 0.40);
     let toolboxNode = dockManager.dockRight(documentNode, toolbox, 0.20);
     let editor1Node = dockManager.dockFill(documentNode, editor1);
     let editor2Node = dockManager.dockFill(documentNode, editor2);

--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@ let solution = new PanelContainer(document.getElementById("solution_window"), do
 let properties = new PanelContainer(document.getElementById("properties_window"), dockManager);
 let toolbox = new PanelContainer(document.getElementById("toolbox_window"), dockManager);
 let outline = new PanelContainer(document.getElementById("outline_window"), dockManager);
-let problems = new PanelContainer(document.getElementById("problems_window"), dockManager);
+let state = new PanelContainer(document.getElementById("state_window"), dockManager);
 let output = new PanelContainer(document.getElementById("output_window"), dockManager);
 let editor1 = new PanelContainer(document.getElementById("editor1_window"), dockManager, null, PanelType.document);
 let editor2 = new PanelContainer(document.getElementById("editor2_window"), dockManager, null, PanelType.document);
@@ -236,7 +236,7 @@ let outlineNode = dockManager.dockLeft(documentNode, outline, 0.15);
 dockManager.dockFill(outlineNode, solution);
 dockManager.dockDown(outlineNode, properties, 0.6);
 let outputNode = dockManager.dockDown(documentNode, output, 0.2);
-dockManager.dockRight(outputNode, problems, 0.40);
+dockManager.dockRight(outputNode, state, 0.40);
 dockManager.dockRight(documentNode, toolbox, 0.20);
 dockManager.dockFill(documentNode, editor1);
 dockManager.dockFill(documentNode, editor2);

--- a/lib/js/PanelContainer.js
+++ b/lib/js/PanelContainer.js
@@ -270,13 +270,13 @@ export class PanelContainer {
         if (this.isDialog) {
             if (this.floatingDialog) {
                 //this.floatingDialog.hide();
-                this.floatingDialog.close();
+                this.floatingDialog.close(); // fires onClose
             }
         }
         else {
             this.performClose();
+            this.dockManager.notifyOnClosePanel(this);
         }
-        this.dockManager.notifyOnClosePanel(this);
     }
 }
 //# sourceMappingURL=PanelContainer.js.map

--- a/page/demo/ide/demo.css
+++ b/page/demo/ide/demo.css
@@ -80,7 +80,7 @@ body {
 	background-color: #ddd;
 }
 
-.problems-window {
+.state-window {
 	width: 300px;
 	height: 200px;
 	background-color: #edd;

--- a/page/demo/ide/demo.html
+++ b/page/demo/ide/demo.html
@@ -67,7 +67,7 @@
             </ul>
         </div>
         <div id="properties_window" data-panel-caption="Properties" class="properties-window" hidden></div>
-        <div id="problems_window" data-panel-caption="Problems" class="problems-window" hidden></div>
+        <div id="state_window" data-panel-caption="State" class="state-window" hidden></div>
         <div id="editor1_window" data-panel-caption="Steering.h" class="editor1-window editor-host" hidden></div>
         <div id="editor2_window" data-panel-caption="Steering.cpp" class="editor2-window editor-host" hidden></div>
         <div id="infovis" data-panel-caption="Dock Tree Visualizer" class="editor2-window editor-host" hidden></div>

--- a/page/demo/ide/demo_smaller_dockcontainer.html
+++ b/page/demo/ide/demo_smaller_dockcontainer.html
@@ -61,7 +61,7 @@
             </ul>
         </div>
         <div id="properties_window" data-panel-caption="Properties" class="properties-window"></div>
-        <div id="problems_window" data-panel-caption="Problems" class="problems-window"></div>
+        <div id="state_window" data-panel-caption="State" class="state-window"></div>
         <div id="editor1_window" data-panel-caption="Steering.h" class="editor1-window editor-host"></div>
         <div id="editor2_window" data-panel-caption="Steering.cpp" class="editor2-window editor-host"></div>
         <div id="infovis" data-panel-caption="Dock Tree Visualizer" class="editor2-window editor-host"></div>

--- a/src/DockManager.ts
+++ b/src/DockManager.ts
@@ -794,6 +794,8 @@ export class DockManager {
         if (value !== this._activePanel) {
             if (value && !value.isDialog) //todo store compliete list of panels, remove the closed ones and switch back focus
                 this._lastPanelNotADialog = value;
+            if (this._lastPanelNotADialog && this.getPanels().indexOf(this._lastPanelNotADialog) < 0)
+                this._lastPanelNotADialog = null;
             let oldActive = this.activePanel;
             if (this.activePanel) {
                 this.activePanel.elementTitle.classList.remove("dockspan-panel-active");
@@ -806,6 +808,12 @@ export class DockManager {
             if (value && value.panelType == PanelType.document) {
                 this._activeDocument = value;
             }
+
+            if (!value && oldActive && oldActive.isDialog && value == null && this._lastPanelNotADialog && this.activePanel != this._lastPanelNotADialog) {
+                value = this._lastPanelNotADialog;
+                this._lastPanelNotADialog = undefined;
+            }
+
             this.notifyOnActivePanelChange(value, oldActive);
             if (value) {
                 value.elementTitle.classList.add("dockspan-panel-active");
@@ -813,9 +821,6 @@ export class DockManager {
                 if (value.tabPage) {
                     value.tabPage.host.setActive(true);
                 }
-            }
-            if (oldActive && oldActive.isDialog && value == null && this._lastPanelNotADialog && this.activePanel != this._lastPanelNotADialog) {
-                this.activePanel = this._lastPanelNotADialog;
             }
         }
         else {

--- a/src/PanelContainer.ts
+++ b/src/PanelContainer.ts
@@ -347,12 +347,12 @@ export class PanelContainer implements IDockContainerWithSize {
         if (this.isDialog) {
             if (this.floatingDialog) {
                 //this.floatingDialog.hide();
-                this.floatingDialog.close();
+                this.floatingDialog.close(); // fires onClose notification
             }
         }
         else {
             this.performClose();
+            this.dockManager.notifyOnClosePanel(this);
         }
-        this.dockManager.notifyOnClosePanel(this);
     }
 }

--- a/src/interfaces/ILayoutEventListener.ts
+++ b/src/interfaces/ILayoutEventListener.ts
@@ -16,7 +16,7 @@ export interface ILayoutEventListener {
     onChangeDialogPosition?(dockManager: DockManager, dialog: Dialog, x: number, y: number): void;
     onContainerResized?(dockManager: DockManager, dockContainer: IDockContainer): void;
     onTabChanged?(dockManager: DockManager, tabpage: TabPage): void;
-    onActivePanelChange?(dockManager: DockManager, panel: PanelContainer, previousPanel?: PanelContainer): void;
+    onActivePanelChange?(dockManager: DockManager, panel?: PanelContainer, previousPanel?: PanelContainer): void;
 
     /**
     * The Dock Manager notifies the listeners of layout changes so client containers that have


### PR DESCRIPTION
When a dialog was closed the close event fired twice
when a panel was closed the onActivePanelChange reported the new panel is undefined (OK), but then next panel selected reported the previous panel as the one that was closed (not undefined)
setting activePanel sometimes caused 2 onActivePanelChange event - x to undefined, undefined to y it now only fires x to y
Fixed optional ? on onActivePanelChange interface def

Changed demo
Output now fills with events are they are generated 
changed problems to state which now displays the state of the dockManager
Fixed issues re-setting layout


Observations - I've not addressed these

These are a big barrier to usability
   - saveState should not save the state of the documents (or at the very least it should be a flag)
   - loadState should be able to work with the existing model, and not re-create it. i.e. You should be able to call loadState on an already configured dockManager without loosing the contents of the panels. 

It should be possible to prevent document windows being docked anywhere but the documentManagerNode, I would suggest a canDock call back somewhere that can decide on what can go where giving the user complete control over restrictions

notifyOnClosePanel should only do what it says (i.e. fire the notification - it also sets panel and document state) 

    notifyOnClosePanel(panel: PanelContainer) {
        this._checkShowBackgroundContext();
        this.layoutEventListeners.forEach((listener) => {
            if (listener.onClosePanel) {
                listener.onClosePanel(this, panel);
            }
        });
        if (this.activePanel == panel)
            this.activePanel = null;
        if (this._activeDocument == panel)
            this._activeDocument = null;
    }

