### PR TITLE
fix: Prevents the title bar of a dialog from being pulled out of the frame so that the close button always remains accessible.

### DIFF
--- a/lib/js/DockManager.js
+++ b/lib/js/DockManager.js
@@ -131,7 +131,7 @@ export class DockManager {
             return this.checkYBoundsWithinDockContainer(container, currentMousePosition, previousMousePosition, resizeNorth, resizeSouth);
         let rect = this.element.getBoundingClientRect();
         let dy = Math.floor(currentMousePosition.y - previousMousePosition.y);
-        let topBounds = container.offsetTop + dy + rect.top < 0;
+        let topBounds = container.offsetTop + dy < 0;
         let bottomBounds = container.offsetTop + dy + rect.top > (window.innerHeight - 16);
         if (topBounds) {
             previousMousePosition.y = currentMousePosition.y;

--- a/src/DockManager.ts
+++ b/src/DockManager.ts
@@ -156,7 +156,7 @@ export class DockManager {
 
         let rect = this.element.getBoundingClientRect();
         let dy = Math.floor(currentMousePosition.y - previousMousePosition.y);
-        let topBounds = container.offsetTop + dy + rect.top < 0;
+        let topBounds = container.offsetTop + dy < 0;
         let bottomBounds = container.offsetTop + dy + rect.top > (window.innerHeight - 16);
         if (topBounds) {
             previousMousePosition.y = currentMousePosition.y;


### PR DESCRIPTION
fix: Prevents the title bar of a dialog from being pulled out of the frame so that the close button always remains accessible.