### PR TITLE
fix: Prevents the title bar of a dialog from being pulled out of the …

### DIFF
--- a/src/DockManager.ts
+++ b/src/DockManager.ts
@@ -156,7 +156,7 @@ export class DockManager {
 
         let rect = this.element.getBoundingClientRect();
         let dy = Math.floor(currentMousePosition.y - previousMousePosition.y);
-        let topBounds = container.offsetTop + dy + rect.top < 0;
+        let topBounds = container.offsetTop + dy < 0;
         let bottomBounds = container.offsetTop + dy + rect.top > (window.innerHeight - 16);
         if (topBounds) {
             previousMousePosition.y = currentMousePosition.y;


### PR DESCRIPTION
fix: Prevents the title bar of a dialog from being pulled out of the frame so that the close button always remains accessible.