### PR TITLE
Make notifyOnActiveDocumentChange async to prevent update conflicts

### DIFF
--- a/src/DockManager.ts
+++ b/src/DockManager.ts
@@ -752,12 +752,12 @@ export class DockManager {
         });
     }
 
-    notifyOnActiveDocumentChange(panel: PanelContainer, oldActive: PanelContainer) {
-        this.layoutEventListeners.forEach((listener) => {
+    async notifyOnActiveDocumentChange(panel: PanelContainer, oldActive: PanelContainer) {
+        for (const listener of this.layoutEventListeners) {
             if (listener.onActiveDocumentChange) {
-                listener.onActiveDocumentChange(this, panel, oldActive);
+                await listener.onActiveDocumentChange(this, panel, oldActive);
             }
-        });
+        }
     }
 
     saveState() {

--- a/src/interfaces/ILayoutEventListener.ts
+++ b/src/interfaces/ILayoutEventListener.ts
@@ -17,7 +17,7 @@ export interface ILayoutEventListener {
     onContainerResized?(dockManager: DockManager, dockContainer: IDockContainer): void;
     onTabChanged?(dockManager: DockManager, tabpage: TabPage): void;
     onActivePanelChange?(dockManager: DockManager, panel?: PanelContainer, previousPanel?: PanelContainer): void;
-    onActiveDocumentChange?(dockManager: DockManager, panel?: PanelContainer, previousPanel?: PanelContainer): void;
+    onActiveDocumentChange?(dockManager: DockManager, panel?: PanelContainer, previousPanel?: PanelContainer): Promise<void>;
 
     /**
     * The Dock Manager notifies the listeners of layout changes so client containers that have


### PR DESCRIPTION
refactor: make notifyOnActiveDocumentChange async to avoid race conditions during document updates